### PR TITLE
Reinstates currently broke end to end

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,11 +10,7 @@ jobs:
       - checkout
       - run: sudo composer self-update
       - run: composer install -n --prefer-dist
-      - run: |
-          # install wget as it can retry on failure
-          sudo apt-get -y -qq install wget
-          # easy zipkin download is broke https://github.com/openzipkin/zipkin/issues/1804
-          wget -O zipkin.jar "$(curl -D- -s 'https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec' | grep '^Location: ' | cut -f2 -d' ' | tr -d $'\r' | sed 's/repo2/repo1/')"
+      - run: curl -sSL https://zipkin.io/quickstart.sh | bash -s
       - run:
           background: true
           command: java -jar zipkin.jar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,18 +15,17 @@ jobs:
           background: true
           command: java -jar zipkin.jar
       # block until zipkin is available
-      - run: wget --retry-connrefused -T 60 http://127.0.0.1:9411/health
+      - run: wget --retry-connrefused -T 60 -O /dev/null http://127.0.0.1:9411/health
       # start both processes in the background, but don't use composer as it dies
       - run:
           background: true
           command: php -S '127.0.0.1:8081' frontend.php
       - run:
           background: true
-          command: php -S '127.0.0.1:9000' frontend.php
+          command: php -S '127.0.0.1:9000' backend.php
       # hit the frontend which calls the backend
-      - run: curl -v --max-time 5 127.0.0.1:8081
+      - run: wget -v --retry-connrefused -T 5 -O /dev/null 127.0.0.1:8081
       - run: |
           # async send to zipkin, so wait a bit before reading back
           sleep 1
           test $(curl -s 127.0.0.1:9411/api/v2/traces | jq '.[0] | length') -eq 3
-


### PR DESCRIPTION
regardless of whether the check here calls the frontend or backend, the result is a timeout https://github.com/openzipkin/zipkin-php-example/blob/f080ca86cf86bed6e26dbf10fb1d430fe02b75f9/.circleci/config.yml#L30

Interesting thing is that the zipkin server starts (else you wouldn't get there). This is reproducible locally by invoking `circleci build` at the root of this branch