### PR TITLE
Adds nightly cronjob

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,3 +29,20 @@ jobs:
           # async send to zipkin, so wait a bit before reading back
           sleep 1
           test $(curl -s 127.0.0.1:9411/api/v2/traces | jq '.[0] | length') -eq 3
+
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - build
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+                - beta
+    jobs:
+      - build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Zipkin PHP example
 
+[![CircleCI](https://circleci.com/gh/openzipkin/zipkin-php-example/tree/master.svg?style=svg)](https://circleci.com/gh/openzipkin/zipkin-php-example/tree/master)
+
 This is an example app where two php services collaborate on an 
 http request. Notably, timing of these requests are recorded into
 Zipkin, a distributed tracing system.


### PR DESCRIPTION
This PR enables the nightly workflow on circleci in order to check that changes in the library do not break the example.

Ping @abesto @adriancole 